### PR TITLE
Inline stack

### DIFF
--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -593,16 +593,10 @@ void frame::interpreter_frame_print_on(outputStream* st) const {
 // Print whether the frame is in the VM or OS indicating a HotSpot problem.
 // Otherwise, it's likely a bug in the native library that the Java code calls,
 // hopefully indicating where to submit bugs.
-void frame::print_C_frame(outputStream* st, char* buf, int buflen, char* res, int reslen, address pc) {
+void frame::print_C_frame(outputStream* st, char* buf, int buflen, address pc) {
   // C/C++ frame
   bool in_vm = os::address_is_in_vm(pc);
-  if (res != nullptr) {
-    res[0] = '\0';
-    int len = strlen(res);
-    jio_snprintf(res + len, reslen - len, in_vm ? "V" : "C");
-  } else {
-    st->print(in_vm ? "V" : "C");
-  }
+  st->print(in_vm ? "V" : "C");
 
   int offset;
   bool found;
@@ -617,28 +611,14 @@ void frame::print_C_frame(outputStream* st, char* buf, int buflen, char* res, in
     p1 = buf;
     int len = (int)strlen(os::file_separator());
     while ((p2 = strstr(p1, os::file_separator())) != nullptr) p1 = p2 + len;
-    if (res != nullptr){
-      int len = strlen(res);
-      jio_snprintf(res + len, reslen - len, "  [%s+0x%x]", p1, offset);
-    } else {
-      st->print("  [%s+0x%x]", p1, offset);
-    }
+    st->print("  [%s+0x%x]", p1, offset);
   } else {
-    if (res != nullptr){
-      int len = strlen(res);
-      jio_snprintf(res + len, reslen - len, "  ");
-    } else {
-      st->print("  " PTR_FORMAT, p2i(pc));
-    }
+    st->print("  " PTR_FORMAT, p2i(pc));
   }
 
   found = os::dll_address_to_function_name(pc, buf, buflen, &offset);
   if (found) {
-    if (res != nullptr){
-      jio_snprintf(res + strlen(res), reslen, "  %s+0x%x", buf, offset);
-    } else {
-      st->print("  %s+0x%x", buf, offset);
-    }
+    st->print("  %s+0x%x", buf, offset);
   }
 }
 
@@ -656,7 +636,7 @@ void frame::print_C_frame(outputStream* st, char* buf, int buflen, char* res, in
 // We don't need detailed frame type as that in frame::print_name(). "C"
 // suggests the problem is in user lib; everything else is likely a VM bug.
 
-void frame::print_on_error(outputStream* st, char* buf, int buflen, char* res, int reslen, bool verbose) const {
+void frame::print_on_error(outputStream* st, char* buf, int buflen, bool verbose) const {
   if (_cb != nullptr) {
     if (Interpreter::contains(pc())) {
       Method* m = this->interpreter_frame_method();
@@ -739,7 +719,7 @@ void frame::print_on_error(outputStream* st, char* buf, int buflen, char* res, i
       st->print("v  blob " PTR_FORMAT, p2i(pc()));
     }
   } else {
-    print_C_frame(st, buf, buflen, res, reslen, pc());
+    print_C_frame(st, buf, buflen, pc());
   }
 }
 

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -594,7 +594,7 @@ void frame::interpreter_frame_print_on(outputStream* st) const {
 // Otherwise, it's likely a bug in the native library that the Java code calls,
 // hopefully indicating where to submit bugs.
 void frame::print_C_frame(outputStream* st, char* buf, int buflen, address pc) {
-  print_C_frame_without_function_name(st, buf, buflen, pc);
+  print_C_frame_prefix(st, buf, buflen, pc);
 
   int offset;
   bool found;
@@ -604,7 +604,7 @@ void frame::print_C_frame(outputStream* st, char* buf, int buflen, address pc) {
   }
 }
 
-void frame::print_C_frame_without_function_name(outputStream* st, char* buf, int buflen, address pc) {
+void frame::print_C_frame_prefix(outputStream* st, char* buf, int buflen, address pc) {
   // C/C++ frame
   bool in_vm = os::address_is_in_vm(pc);
   st->print(in_vm ? "V" : "C");

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -594,6 +594,17 @@ void frame::interpreter_frame_print_on(outputStream* st) const {
 // Otherwise, it's likely a bug in the native library that the Java code calls,
 // hopefully indicating where to submit bugs.
 void frame::print_C_frame(outputStream* st, char* buf, int buflen, address pc) {
+  print_C_frame_without_function_name(st, buf, buflen, pc);
+
+  int offset;
+  bool found;
+  found = os::dll_address_to_function_name(pc, buf, buflen, &offset);
+  if (found) {
+    st->print("  %s+0x%x", buf, offset);
+  }
+}
+
+void frame::print_C_frame_without_function_name(outputStream* st, char* buf, int buflen, address pc) {
   // C/C++ frame
   bool in_vm = os::address_is_in_vm(pc);
   st->print(in_vm ? "V" : "C");
@@ -614,11 +625,6 @@ void frame::print_C_frame(outputStream* st, char* buf, int buflen, address pc) {
     st->print("  [%s+0x%x]", p1, offset);
   } else {
     st->print("  " PTR_FORMAT, p2i(pc));
-  }
-
-  found = os::dll_address_to_function_name(pc, buf, buflen, &offset);
-  if (found) {
-    st->print("  %s+0x%x", buf, offset);
   }
 }
 

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -421,6 +421,7 @@ class frame {
   void interpreter_frame_print_on(outputStream* st) const;
   void print_on_error(outputStream* st, char* buf, int buflen, bool verbose = false) const;
   static void print_C_frame(outputStream* st, char* buf, int buflen, address pc);
+  static void print_C_frame_without_function_name(outputStream* st, char* buf, int buflen, address pc);
 
   // Add annotated descriptions of memory locations belonging to this frame to values
   void describe(FrameValues& values, int frame_no, const RegisterMap* reg_map=nullptr);

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -419,8 +419,8 @@ class frame {
   void print_value_on(outputStream* st, JavaThread *thread) const;
   void print_on(outputStream* st) const;
   void interpreter_frame_print_on(outputStream* st) const;
-  void print_on_error(outputStream* st, char* buf, int buflen, char* res, int reslen, bool verbose = false) const;
-  static void print_C_frame(outputStream* st, char* buf, int buflen, char* res, int reslen, address pc);
+  void print_on_error(outputStream* st, char* buf, int buflen, bool verbose = false) const;
+  static void print_C_frame(outputStream* st, char* buf, int buflen, address pc);
 
   // Add annotated descriptions of memory locations belonging to this frame to values
   void describe(FrameValues& values, int frame_no, const RegisterMap* reg_map=nullptr);

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -421,7 +421,7 @@ class frame {
   void interpreter_frame_print_on(outputStream* st) const;
   void print_on_error(outputStream* st, char* buf, int buflen, bool verbose = false) const;
   static void print_C_frame(outputStream* st, char* buf, int buflen, address pc);
-  static void print_C_frame_without_function_name(outputStream* st, char* buf, int buflen, address pc);
+  static void print_C_frame_prefix(outputStream* st, char* buf, int buflen, address pc);
 
   // Add annotated descriptions of memory locations belonging to this frame to values
   void describe(FrameValues& values, int frame_no, const RegisterMap* reg_map=nullptr);

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -419,8 +419,8 @@ class frame {
   void print_value_on(outputStream* st, JavaThread *thread) const;
   void print_on(outputStream* st) const;
   void interpreter_frame_print_on(outputStream* st) const;
-  void print_on_error(outputStream* st, char* buf, int buflen, bool verbose = false) const;
-  static void print_C_frame(outputStream* st, char* buf, int buflen, address pc);
+  void print_on_error(outputStream* st, char* buf, int buflen, char* res, int reslen, bool verbose = false) const;
+  static void print_C_frame(outputStream* st, char* buf, int buflen, char* res, int reslen, address pc);
 
   // Add annotated descriptions of memory locations belonging to this frame to values
   void describe(FrameValues& values, int frame_no, const RegisterMap* reg_map=nullptr);

--- a/src/hotspot/share/utilities/decoder.cpp
+++ b/src/hotspot/share/utilities/decoder.cpp
@@ -113,12 +113,12 @@ bool Decoder::demangle(const char* symbol, char* buf, int buflen) {
 void Decoder::print_state_on(outputStream* st) {
 }
 
-bool Decoder::get_source_info(address pc, char* filename, size_t filename_len, int* line, bool is_pc_after_call) {
+bool Decoder::get_source_info(address pc, char* buf, int buflen, bool is_pc_after_call) {
   if (VMError::is_error_reported_in_current_thread()) {
-    return get_error_handler_instance()->get_source_info(pc, filename, filename_len, line, is_pc_after_call);
+    return get_error_handler_instance()->get_source_info(pc, buf, buflen, is_pc_after_call);
   } else {
     MutexLocker locker(shared_decoder_lock(), Mutex::_no_safepoint_check_flag);
-    return get_shared_instance()->get_source_info(pc, filename, filename_len, line, is_pc_after_call);
+    return get_shared_instance()->get_source_info(pc, buf, buflen, is_pc_after_call);
   }
 }
 

--- a/src/hotspot/share/utilities/decoder.cpp
+++ b/src/hotspot/share/utilities/decoder.cpp
@@ -113,12 +113,12 @@ bool Decoder::demangle(const char* symbol, char* buf, int buflen) {
 void Decoder::print_state_on(outputStream* st) {
 }
 
-bool Decoder::get_source_info(address pc, char* buf, size_t buflen, bool is_pc_after_call) {
+bool Decoder::get_source_info(address pc, GrowableArrayCHeap<char*, mtInternal>* infoList, size_t buflen, bool is_pc_after_call) {
   if (VMError::is_error_reported_in_current_thread()) {
-    return get_error_handler_instance()->get_source_info(pc, buf, buflen, is_pc_after_call);
+    return get_error_handler_instance()->get_source_info(pc, infoList, buflen, is_pc_after_call);
   } else {
     MutexLocker locker(shared_decoder_lock(), Mutex::_no_safepoint_check_flag);
-    return get_shared_instance()->get_source_info(pc, buf, buflen, is_pc_after_call);
+    return get_shared_instance()->get_source_info(pc, infoList, buflen, is_pc_after_call);
   }
 }
 

--- a/src/hotspot/share/utilities/decoder.cpp
+++ b/src/hotspot/share/utilities/decoder.cpp
@@ -113,7 +113,7 @@ bool Decoder::demangle(const char* symbol, char* buf, int buflen) {
 void Decoder::print_state_on(outputStream* st) {
 }
 
-bool Decoder::get_source_info(address pc, char* buf, int buflen, bool is_pc_after_call) {
+bool Decoder::get_source_info(address pc, char* buf, size_t buflen, bool is_pc_after_call) {
   if (VMError::is_error_reported_in_current_thread()) {
     return get_error_handler_instance()->get_source_info(pc, buf, buflen, is_pc_after_call);
   } else {

--- a/src/hotspot/share/utilities/decoder.hpp
+++ b/src/hotspot/share/utilities/decoder.hpp
@@ -29,6 +29,7 @@
 #include "memory/allStatic.hpp"
 #include "runtime/mutex.hpp"
 #include "runtime/mutexLocker.hpp"
+#include "utilities/growableArray.hpp"
 #include "utilities/ostream.hpp"
 
 class AbstractDecoder : public CHeapObj<mtInternal> {
@@ -66,7 +67,7 @@ public:
   virtual bool demangle(const char* symbol, char* buf, int buflen) = 0;
 
   // Get inline function stack, file name and line number  information.
-  virtual bool get_source_info(address pc, char* buf, size_t buflen, bool is_pc_after_call) {
+  virtual bool get_source_info(address pc, GrowableArrayCHeap<char*, mtInternal>* infoList, size_t buflen, bool is_pc_after_call) {
     return false;
   }
 
@@ -116,7 +117,7 @@ public:
   // Attempts to retrieve inline function stack, source file name and line number associated with a pc.
   // If is_pc_after_call is true, then pc is treated as pointing to the next instruction
   // after a call. The source information for the call instruction is fetched in that case.
-  static bool get_source_info(address pc, char* buf, size_t buflen, bool is_pc_after_call = false);
+  static bool get_source_info(address pc, GrowableArrayCHeap<char*, mtInternal>* infoList, size_t buflen, bool is_pc_after_call = false);
 
   static void print_state_on(outputStream* st);
 

--- a/src/hotspot/share/utilities/decoder.hpp
+++ b/src/hotspot/share/utilities/decoder.hpp
@@ -66,7 +66,7 @@ public:
   virtual bool demangle(const char* symbol, char* buf, int buflen) = 0;
 
   // Get inline function stack, file name and line number  information.
-  virtual bool get_source_info(address pc, char* buf, int buflen, bool is_pc_after_call) {
+  virtual bool get_source_info(address pc, char* buf, size_t buflen, bool is_pc_after_call) {
     return false;
   }
 
@@ -116,7 +116,7 @@ public:
   // Attempts to retrieve inline function stack, source file name and line number associated with a pc.
   // If is_pc_after_call is true, then pc is treated as pointing to the next instruction
   // after a call. The source information for the call instruction is fetched in that case.
-  static bool get_source_info(address pc, char* buf, int buflen, bool is_pc_after_call = false);
+  static bool get_source_info(address pc, char* buf, size_t buflen, bool is_pc_after_call = false);
 
   static void print_state_on(outputStream* st);
 

--- a/src/hotspot/share/utilities/decoder.hpp
+++ b/src/hotspot/share/utilities/decoder.hpp
@@ -65,8 +65,8 @@ public:
   // demangle a C++ symbol
   virtual bool demangle(const char* symbol, char* buf, int buflen) = 0;
 
-  // Get filename and line number information.
-  virtual bool get_source_info(address pc, char* filename, size_t filename_len, int* line, bool is_pc_after_call) {
+  // Get inline function stack, file name and line number  information.
+  virtual bool get_source_info(address pc, char* buf, int buflen, bool is_pc_after_call) {
     return false;
   }
 
@@ -113,12 +113,10 @@ public:
   static bool decode(address pc, char* buf, int buflen, int* offset, const void* base);
   static bool demangle(const char* symbol, char* buf, int buflen);
 
-  // Attempts to retrieve source file name and line number associated with a pc.
-  // If filename != nullptr, points to a buffer of size filename_len which will receive the
-  // file name. File name will be silently truncated if output buffer is too small.
+  // Attempts to retrieve inline function stack, source file name and line number associated with a pc.
   // If is_pc_after_call is true, then pc is treated as pointing to the next instruction
   // after a call. The source information for the call instruction is fetched in that case.
-  static bool get_source_info(address pc, char* filename, size_t filename_len, int* line, bool is_pc_after_call = false);
+  static bool get_source_info(address pc, char* buf, int buflen, bool is_pc_after_call = false);
 
   static void print_state_on(outputStream* st);
 

--- a/src/hotspot/share/utilities/decoder_elf.cpp
+++ b/src/hotspot/share/utilities/decoder_elf.cpp
@@ -54,15 +54,13 @@ bool ElfDecoder::decode(address addr, char *buf, int buflen, int* offset, const 
   return true;
 }
 
-bool ElfDecoder::get_source_info(address pc, char* filename, size_t filename_len, int* line, bool is_pc_after_call) {
+bool ElfDecoder::get_source_info(address pc, char* buf, int buflen, bool is_pc_after_call) {
 #if defined(__clang_major__) && (__clang_major__ < 5)
   DWARF_LOG_ERROR("The DWARF parser only supports Clang 5.0+.");
   return false;
 #else
-  assert(filename != nullptr && line != nullptr, "arguments should not be null");
-  assert(filename_len > 1, "buffer must be able to at least hold 1 character with a null terminator");
-  filename[0] = '\0';
-  *line = -1;
+  assert(buf != nullptr && buflen > 0, "Argument error");
+  buf[0] = '\0';
 
   char filepath[JVM_MAXPATHLEN];
   filepath[JVM_MAXPATHLEN - 1] = '\0';
@@ -87,20 +85,14 @@ bool ElfDecoder::get_source_info(address pc, char* filename, size_t filename_len
   DWARF_LOG_INFO("##### Find filename and line number for offset " INT32_FORMAT_X_0 " in library %s #####",
                  unsigned_offset_in_library, filepath);
 
-  if (!file->get_source_info(unsigned_offset_in_library, filename, filename_len, line, is_pc_after_call)) {
-    // Return sane values.
-    filename[0] = '\0';
-    *line = -1;
+  if (!file->get_source_info(unsigned_offset_in_library, buf, buflen, is_pc_after_call)) {
     return false;
   }
 
-  DWARF_LOG_SUMMARY("pc: " PTR_FORMAT ", offset: " INT32_FORMAT_X_0 ", filename: %s, line: %u",
-                       p2i(pc), offset_in_library, filename, *line);
   DWARF_LOG_INFO("") // To structure the debug output better.
   return true;
 #endif // clang
 }
-
 
 ElfFile* ElfDecoder::get_elf_file(const char* filepath) {
   ElfFile* file;

--- a/src/hotspot/share/utilities/decoder_elf.cpp
+++ b/src/hotspot/share/utilities/decoder_elf.cpp
@@ -54,13 +54,12 @@ bool ElfDecoder::decode(address addr, char *buf, int buflen, int* offset, const 
   return true;
 }
 
-bool ElfDecoder::get_source_info(address pc, char* buf, size_t buflen, bool is_pc_after_call) {
+bool ElfDecoder::get_source_info(address pc, GrowableArrayCHeap<char*, mtInternal>* infoList, size_t buflen, bool is_pc_after_call) {
 #if defined(__clang_major__) && (__clang_major__ < 5)
   DWARF_LOG_ERROR("The DWARF parser only supports Clang 5.0+.");
   return false;
 #else
-  assert(buf != nullptr && buflen > 0, "Argument error");
-  buf[0] = '\0';
+  assert(buflen > 0, "Argument error");
 
   char filepath[JVM_MAXPATHLEN];
   filepath[JVM_MAXPATHLEN - 1] = '\0';
@@ -85,9 +84,8 @@ bool ElfDecoder::get_source_info(address pc, char* buf, size_t buflen, bool is_p
   DWARF_LOG_INFO("##### Find filename and line number for offset " INT32_FORMAT_X_0 " in library %s #####",
                  unsigned_offset_in_library, filepath);
 
-  if (!file->get_source_info(unsigned_offset_in_library, buf, buflen, is_pc_after_call)) {
+  if (!file->get_source_info(unsigned_offset_in_library, infoList, buflen, is_pc_after_call)) {
     // Return sane values.
-    buf[0] = '\0';
     return false;
   }
 

--- a/src/hotspot/share/utilities/decoder_elf.cpp
+++ b/src/hotspot/share/utilities/decoder_elf.cpp
@@ -54,7 +54,7 @@ bool ElfDecoder::decode(address addr, char *buf, int buflen, int* offset, const 
   return true;
 }
 
-bool ElfDecoder::get_source_info(address pc, char* buf, int buflen, bool is_pc_after_call) {
+bool ElfDecoder::get_source_info(address pc, char* buf, size_t buflen, bool is_pc_after_call) {
 #if defined(__clang_major__) && (__clang_major__ < 5)
   DWARF_LOG_ERROR("The DWARF parser only supports Clang 5.0+.");
   return false;
@@ -86,6 +86,8 @@ bool ElfDecoder::get_source_info(address pc, char* buf, int buflen, bool is_pc_a
                  unsigned_offset_in_library, filepath);
 
   if (!file->get_source_info(unsigned_offset_in_library, buf, buflen, is_pc_after_call)) {
+    // Return sane values.
+    buf[0] = '\0';
     return false;
   }
 

--- a/src/hotspot/share/utilities/decoder_elf.hpp
+++ b/src/hotspot/share/utilities/decoder_elf.hpp
@@ -43,7 +43,7 @@ public:
     ShouldNotReachHere();
     return false;
   }
-  bool get_source_info(address pc, char* buf, int buflen, bool is_pc_after_call);
+  bool get_source_info(address pc, char* buf, size_t buflen, bool is_pc_after_call);
 
 private:
   ElfFile*         get_elf_file(const char* filepath);

--- a/src/hotspot/share/utilities/decoder_elf.hpp
+++ b/src/hotspot/share/utilities/decoder_elf.hpp
@@ -43,7 +43,7 @@ public:
     ShouldNotReachHere();
     return false;
   }
-  bool get_source_info(address pc, char* buf, size_t buflen, int* line, bool is_pc_after_call);
+  bool get_source_info(address pc, char* buf, int buflen, bool is_pc_after_call);
 
 private:
   ElfFile*         get_elf_file(const char* filepath);

--- a/src/hotspot/share/utilities/decoder_elf.hpp
+++ b/src/hotspot/share/utilities/decoder_elf.hpp
@@ -29,6 +29,7 @@
 
 #include "utilities/decoder.hpp"
 #include "utilities/elfFile.hpp"
+#include "utilities/growableArray.hpp"
 
 class ElfDecoder : public AbstractDecoder {
 
@@ -43,7 +44,7 @@ public:
     ShouldNotReachHere();
     return false;
   }
-  bool get_source_info(address pc, char* buf, size_t buflen, bool is_pc_after_call);
+  bool get_source_info(address pc, GrowableArrayCHeap<char*, mtInternal>* infoList, size_t buflen, bool is_pc_after_call);
 
 private:
   ElfFile*         get_elf_file(const char* filepath);

--- a/src/hotspot/share/utilities/elfFile.hpp
+++ b/src/hotspot/share/utilities/elfFile.hpp
@@ -198,7 +198,7 @@ class ElfFile: public CHeapObj<mtInternal> {
   // On systems other than linux it always returns false.
   static bool specifies_noexecstack(const char* filepath) NOT_LINUX({ return false; });
 
-  bool get_source_info(uint32_t offset_in_library, char* buf, int buflen, bool is_pc_after_call);
+  bool get_source_info(uint32_t offset_in_library, char* buf, size_t buflen, bool is_pc_after_call);
 
  private:
   // sanity check, if the file is a real elf file
@@ -460,7 +460,7 @@ class DwarfFile : public ElfFile {
   static const size_t STRING_BUF_LEN = 256;
   static constexpr const char* overflow_msg = "<OVERFLOW>";
   static constexpr const char minimal_overflow_msg = 'L';
-  static void write_buf(char* buf, int buflen, char* str);
+  static void write_source_info_buf(char* buf, size_t buflen, char* str);
 
   class MarkedDwarfFileReader : public MarkedFileReader {
    private:
@@ -656,7 +656,7 @@ class DwarfFile : public ElfFile {
 
     bool offset_in_range(uint32_t offset, const bool is_pc_after_call);
     bool read_attribute_value(const uint64_t attribute_form, const uint64_t attribute_name);
-    bool get_inlined_info( const uint32_t offset_in_library, char* buf, int buflen, const bool is_pc_after_call, bool first, uint32_t pre_origin);
+    bool get_inlined_info( const uint32_t offset_in_library, char* buf, size_t buflen, const bool is_pc_after_call, bool first, uint32_t pre_origin);
     bool get_parent();
 
     DwarfFile* _dwarf_file;
@@ -1048,7 +1048,7 @@ class DwarfFile : public ElfFile {
    *  More details about the different phases can be found at the associated methods.
    */
   bool get_filename_and_line_number(uint32_t offset_in_library, char* filename, size_t filename_len, int* line, bool is_pc_after_call);
-  bool get_inlined_info(uint32_t offset_in_library, char* buf, int buflen, bool is_pc_after_call);
+  bool get_inlined_info(uint32_t offset_in_library, char* buf, size_t buflen, bool is_pc_after_call);
 };
 
 #endif // !_WINDOWS && !__APPLE__

--- a/src/hotspot/share/utilities/elfFile.hpp
+++ b/src/hotspot/share/utilities/elfFile.hpp
@@ -71,6 +71,7 @@ typedef Elf32_Sym       Elf_Sym;
 #include "globalDefinitions.hpp"
 #include "memory/allocation.hpp"
 #include "utilities/decoder.hpp"
+#include "utilities/growableArray.hpp"
 
 #ifdef ASSERT
 // Helper macros to print different log levels during DWARF parsing
@@ -198,7 +199,7 @@ class ElfFile: public CHeapObj<mtInternal> {
   // On systems other than linux it always returns false.
   static bool specifies_noexecstack(const char* filepath) NOT_LINUX({ return false; });
 
-  bool get_source_info(uint32_t offset_in_library, char* buf, size_t buflen, bool is_pc_after_call);
+  bool get_source_info(uint32_t offset_in_library, GrowableArrayCHeap<char*, mtInternal>* infoList, size_t buflen, bool is_pc_after_call);
 
  private:
   // sanity check, if the file is a real elf file
@@ -656,7 +657,7 @@ class DwarfFile : public ElfFile {
 
     bool offset_in_range(uint32_t offset, const bool is_pc_after_call);
     bool read_attribute_value(const uint64_t attribute_form, const uint64_t attribute_name);
-    bool get_inlined_info( const uint32_t offset_in_library, char* buf, size_t buflen, const bool is_pc_after_call, bool first, uint32_t pre_origin);
+    bool get_inlined_info( const uint32_t offset_in_library, GrowableArrayCHeap<char*, mtInternal>* infoList, size_t buflen, const bool is_pc_after_call, bool first, uint32_t pre_origin);
     bool get_parent();
 
     DwarfFile* _dwarf_file;
@@ -1048,7 +1049,7 @@ class DwarfFile : public ElfFile {
    *  More details about the different phases can be found at the associated methods.
    */
   bool get_filename_and_line_number(uint32_t offset_in_library, char* filename, size_t filename_len, int* line, bool is_pc_after_call);
-  bool get_inlined_info(uint32_t offset_in_library, char* buf, size_t buflen, bool is_pc_after_call);
+  bool get_inlined_info(uint32_t offset_in_library, GrowableArrayCHeap<char*, mtInternal>* infoList, size_t buflen, bool is_pc_after_call);
 };
 
 #endif // !_WINDOWS && !__APPLE__

--- a/src/hotspot/share/utilities/elfFile.hpp
+++ b/src/hotspot/share/utilities/elfFile.hpp
@@ -567,7 +567,7 @@ class DwarfFile : public ElfFile {
 
   // (3a-b) The compilation unit is read from the .debug_info section. The structure of .debug_info is shown in the
   // comments of class DebugAbbrev.
-  class CompilationUnit {
+  class CompilationUnit : public ResourceObj {
 
     // The header is defined in section 7.5.1.1 of the DWARF 4 spec.
     struct CompilationUnitHeader {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -308,7 +308,7 @@ void VMError::print_stack_trace(outputStream* st, JavaThread* jt,
   if (jt->has_last_Java_frame()) {
     st->print_cr("Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)");
     for (StackFrameStream sfs(jt, true /* update */, true /* process_frames */); !sfs.is_done(); sfs.next()) {
-      sfs.current()->print_on_error(st, buf, buflen, nullptr, 0, verbose);
+      sfs.current()->print_on_error(st, buf, buflen, verbose);
       st->cr();
     }
   }
@@ -449,8 +449,9 @@ void VMError::print_native_stack(outputStream* st, frame fr, Thread* t, bool pri
     const int limit = max_frames == -1 ? StackPrintLimit : MIN2(max_frames, (int)StackPrintLimit);
     int count = 0;
     while (count++ < limit) {
-      char res[1024];
-      fr.print_on_error(st, buf, buf_size, res, sizeof(res));
+      stringStream ss;
+      fr.print_on_error(&ss, buf, buf_size);
+      char* res = ss.as_string();
       if (fr.pc()) { // print source file and line, if available
         char newbuf[2048];
         if (print_source_info &&
@@ -475,7 +476,7 @@ void VMError::print_native_stack(outputStream* st, frame fr, Thread* t, bool pri
           s[end] = '\0';
           st->print_cr("%s%s", res, s);
         } else {
-          st->cr();
+          st->print_cr("%s", res);
         }
       }
       fr = next_frame(fr, t);
@@ -909,7 +910,7 @@ void VMError::report(outputStream* st, bool _verbose) {
     st->print_cr("# Problematic frame:");
     st->print("# ");
     frame fr = os::fetch_frame_from_context(_context);
-    fr.print_on_error(st, buf, sizeof(buf), nullptr, 0);
+    fr.print_on_error(st, buf, sizeof(buf));
     st->cr();
     st->print_cr("#");
 

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -451,20 +451,19 @@ void VMError::print_native_stack(outputStream* st, frame fr, Thread* t, bool pri
     while (count++ < limit) {
       if (fr.pc()) { // print source file and line, if available
         GrowableArrayCHeap<char*, mtInternal> infoList(3);
+        ResourceMark rm;
         if (print_source_info &&
-                   Decoder::get_source_info(fr.pc(), &infoList, 1024, count != 1)) {
+                   Decoder::get_source_info(fr.pc(), &infoList, 256, count != 1)) {
           // Get the information of lib and offset. eg. V  [libjvm.so+0x1980e3d]
           stringStream ss;
           fr.print_C_frame_prefix(&ss, buf, buf_size, fr.pc());
           // We get the inline stack information from top to bottom via get_source_info, but we should print it reversely.
           for (int i = infoList.length() - 1; i > 0; i--) {
             st->print_cr("%s%s  [inline]", ss.as_string(), infoList.at(i));
-            os::free(infoList.at(i));
           }
-          fr.print_on_error(st, buf, buf_size);
+          fr.print_C_frame(st, buf, buf_size, fr.pc());
           if (infoList.length() > 0) {
             st->print("%s", infoList.at(0));
-            os::free(infoList.at(0));
           }
         } else {
           fr.print_on_error(st, buf, buf_size);

--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -443,6 +443,7 @@ TEST_VM(os_linux, decoder_get_source_info_valid) {
   int line = -1;
   address valid_function_pointer = (address)ReportJNIFatalError;
   GrowableArrayCHeap<char*, mtInternal>* infoList = new GrowableArrayCHeap<char*, mtInternal>(3);
+  ResourceMark rm;
   ASSERT_TRUE(Decoder::get_source_info(valid_function_pointer, infoList, 1024, false));
   ASSERT_TRUE(!infoList->is_empty());
   char* buf = infoList->pop();
@@ -464,6 +465,7 @@ TEST_VM(os_linux, decoder_get_source_info_invalid) {
 
   for (address addr : invalid_function_pointers) {
     GrowableArrayCHeap<char*, mtInternal>* infoList = new GrowableArrayCHeap<char*, mtInternal>(3);
+    ResourceMark rm;
     // We should return false but do not crash or fail in any way.
     ASSERT_FALSE(Decoder::get_source_info(addr, infoList, 1024, false));
     ASSERT_TRUE(infoList->is_empty()); // Should contain "" on error
@@ -474,6 +476,7 @@ TEST_VM(os_linux, decoder_get_source_info_invalid) {
 TEST_VM(os_linux, decoder_get_source_info_valid_overflow) {
   address valid_function_pointer = (address)ReportJNIFatalError;
   GrowableArrayCHeap<char*, mtInternal>* infoList = new GrowableArrayCHeap<char*, mtInternal>(3);
+  ResourceMark rm;
   ASSERT_TRUE(Decoder::get_source_info(valid_function_pointer, infoList, 11, false));
   ASSERT_TRUE(strcmp(infoList->pop(), "<OVERFLOW>") == 0);
 }
@@ -483,6 +486,7 @@ TEST_VM(os_linux, decoder_get_source_info_valid_overflow) {
 TEST_VM(os_linux, decoder_get_source_info_valid_overflow_minimal) {
   address valid_function_pointer = (address)ReportJNIFatalError;
   GrowableArrayCHeap<char*, mtInternal>* infoList = new GrowableArrayCHeap<char*, mtInternal>(3);
+  ResourceMark rm;
   ASSERT_TRUE(Decoder::get_source_info(valid_function_pointer, infoList, 2, false));
   ASSERT_TRUE(strcmp(infoList->pop(), "L") == 0); // Overflow message does not fit, so we fall back to "L:line_number"
 }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
@@ -132,7 +132,7 @@ public class TestDwarf {
             boolean foundNativeFrames = false;
             int matches = 0;
             int frameIdx = 0;
-            Pattern pattern = Pattern.compile("[CV][\\s\\t]+\\[([a-zA-Z0-9_.]+)\\+0x.+][\\s\\t]+.*\\+0x.+[\\s\\t]+\\([a-zA-Z0-9_.]+\\.[a-z]+:[1-9][0-9]*\\)");
+            Pattern pattern = Pattern.compile("[CV][\\s\\t]+\\[([a-zA-Z0-9_.]+)\\+0x.+][\\s\\t]+.*\\([a-zA-Z0-9_.]+\\.[a-z]+:[1-9][0-9]*\\)");
             // Check all stack entries after the line starting with "Native frames" in the hs_err_file until an empty line
             // is found which denotes the end of the stack frames.
             while ((line = reader.readLine()) != null) {


### PR DESCRIPTION
I noticed the same problem with JDK-8305005[1] that the function name sometimes not match with the source line information in hs_err file. As Dean Long said, the code that gets the function name is using **dladdr()**, so it gets the **outer-most** frame. The code that gets the file name and line number is using ElfDecoder-->ElfFile-->DwarfFile and gets the **inner-most** frame. I think the problem can be solved by expanding the inline functions of each frame. 


```
V  [libjvm.so+0x1a02121]  VMError::controlled_crash(int)+0xc1  (vmError.cpp:1848) 
```


For example, as above, **vmError.cpp:1832** is in **crash_with_sigfpe**, however, because of the inlining of **crash_with_sigfpe**, **dladdr()** can only get the outer-most frame **controlled_crash**. By expanding the inline functions of the frame, we can get the following frames:


```
V  [libjvm.so+0x1a02121]  crash_with_sigfpe  (vmError.cpp:1848)  [inline]
V  [libjvm.so+0x1a02121]  VMError::controlled_crash(int)+0xc1  (vmError.cpp:1895)
```


Thus the function name can be consistent with source line information.

I did the work on the basic of [JDK-8242181](https://github.com/openjdk/jdk/pull/7126/commits), which provides the functions of reading dwarf file , compilation unit and get filename and line number from .debug_line section. Based on that, I implemented the functions of  reading DIE, child iteration of DIE, and get inline info by traversing the DIEs.

The critical function is how to get the inline info.  Let's take the example of the frame mentioned above. The DebuggingInfoEntry has a structure as directory as follwoing:
```
Compilation Unit
Top DIE
  	DIE 1
  		DIE a
 		DIE b
	DIE 2
		DIE c
			DIE d
	DIE 3
```
 We can traverse the children of top DIE to get the inline information.
Given an offset 0x1a02121, firstly, we can find the compilation unit containing the offset by .debug_arranges section, and then, we can get the top DIE of the compilation unit, as following(the dwarf info is decoded by dwarfdump):
![image](https://github.com/openjdk/jdk/assets/82255739/f6fd3a9b-ca0a-4f71-9e66-4b0b05035cb1)
![image](https://github.com/openjdk/jdk/assets/82255739/a7510a1d-41c9-48b9-b263-2b14f83b24f1)
And then, we can iterate the children of the top DIE to find the DIE containing the offset of 0x1a02121, the DIE we find as following:
![image](https://github.com/openjdk/jdk/assets/82255739/4cfe4cf2-b2d2-4dfb-b4a5-5e6a96d5a459)
Then we find the outer-most function **controlled_crash** of offset 0x1a02121, and we can discard this function name because we can get it by **dladdr()**. Then we itearte the children of this DIE ad find the next DIE containing the offset.
![image](https://github.com/openjdk/jdk/assets/82255739/095ec242-04c5-4ecc-9632-7e73076c5315)
From the DIE we can get function name **crash_with_sigfpe**, filename **vmError.cpp** and line number **1895** which indicates that **crash_with_sigfpe** be called by **controlled_crash** at **vmError.cpp:1895**. We iterate the children of the DIE and then found no DIE containing the offset thus the traverse is terminated.
After that, we get the source information **(vmError.cpp:1895)** and **crash_with_sigfpe**. Then we can get the filename and line number **(vmError.cpp:1848)** of the inner-most frame (in **crash_with_sigfpe**) which has been realized by [JDK-8242181](https://github.com/openjdk/jdk/pull/7126/commits). So far, we can get the inline source information:

```
(vmError.cpp:1895)
crash_with_sigfpe (vmError.cpp:1848)
```
And in combination of the information acquired by dladdr() we can get the full inline source information.